### PR TITLE
Handle optional byte in chassis status response.

### DIFF
--- a/chassis.go
+++ b/chassis.go
@@ -180,6 +180,23 @@ func (r *SystemBootOptionsResponse) UnmarshalBinary(buf []byte) error {
 	return nil
 }
 
+// UnmarshalBinary implementation to handle variable length Data
+func (r *ChassisStatusResponse) UnmarshalBinary(buf []byte) error {
+	if len(buf) < 4 {
+		return ErrShortPacket
+	}
+	r.CompletionCode = CompletionCode(buf[0])
+	r.PowerState = buf[1]
+	r.LastPowerEvent =  buf[2]
+	r.State = buf[3]
+	if len(buf) > 4 {
+		r.FrontControlPanel = buf[4]
+	} else {
+		r.FrontControlPanel = 0
+	}
+	return nil
+}
+
 func (r *SystemBootOptionsResponse) BootDeviceSelector() BootDevice {
 	return BootDevice(((r.Data[1] >> 2) & 0x0f) << 2)
 }


### PR DESCRIPTION
The fifth byte in the chassis status response is optional. Add a custom unmarshalling routine for the chassis status response to handle all of the possible conditions.
