### PR TITLE
Enable chassis identify set/get.

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package ipmi
 
+import "fmt"
+
 // Client provides common high level functionality around the underlying transport
 type Client struct {
 	*Connection
@@ -117,4 +119,25 @@ func (c *Client) Control(ctl ChassisControl) error {
 		&ChassisControlRequest{ctl},
 	}
 	return c.Send(r, &ChassisControlResponse{})
+}
+
+func (c *Client) Identify(time int, indefinitely bool) error {
+	if time > 255 || time < 0 {
+		return fmt.Errorf("invalid time value")
+	}
+	var force uint8
+	if indefinitely {
+		force = 1
+	} else {
+		force = 0
+	}
+	r := &Request{
+		NetworkFunctionChassis,
+		CommandChassisIdentify,
+		&ChassisIdentifyRequest{
+			Interval: uint8(time),
+			Force:    force,
+		},
+	}
+	return c.Send(r, &ChassisIdentifyResponse{})
 }

--- a/command.go
+++ b/command.go
@@ -31,6 +31,7 @@ const (
 	CommandChassisStatus            = Command(0x01)
 	CommandSetSystemBootOptions     = Command(0x08)
 	CommandGetSystemBootOptions     = Command(0x09)
+	CommandChassisIdentify          = Command(0x04)
 )
 
 // Request structure


### PR DESCRIPTION
Turn on for a period of seconds, turn on indefinitely, and turn off (0 seconds). Get state of chassis identify, if supported (as defined in version 2.0 of IPMI specification).