### PR TITLE
fix UT failure

### DIFF
--- a/tool_test.go
+++ b/tool_test.go
@@ -148,7 +148,7 @@ func TestTool(t *testing.T) {
 	err = tr.send(req, bor)
 	assert.NoError(t, err)
 	assert.Equal(t, uint8(BootParamBootFlags), bor.Param)
-	assert.Equal(t, uint8(BootDevicePxe), bor.BootDeviceSelector())
+	assert.Equal(t, BootDevicePxe, bor.BootDeviceSelector())
 	assert.Equal(t, uint8(0x40), bor.Data[1]&0x40)
 
 	// Invalid command


### PR DESCRIPTION
Previous it has failure

```
$ go test
--- FAIL: TestTool (0.04s)
    tool_test.go:151:
              Error Trace:  tool_test.go:151
              Error:        Not equal:
                            expected: uint8(0x4)
                            actual : ipmi.BootDevice(0x4)
              Test:         TestTool
FAIL
exit status 1
FAIL github.com/vmware/goipmi 0.060s
```

Signed-off-by: Leslie Qi Wang <leslie.qiwa@gmail.com>